### PR TITLE
Add support for FTLDriveContinued

### DIFF
--- a/GPTT_yonge.cfg
+++ b/GPTT_yonge.cfg
@@ -11335,6 +11335,10 @@ TechTree
 			part = ZWarpDrive25 //2.5m Drive
 			part = ZWarpDrive375 //3.75m Drive
 			part = ZWarpDrive375 //3.75m Drive
+			part = advancedFTLdriveMk2
+			part = advancedFTLdriveS2
+			part = advancedFTLdriveS1
+			part = ftlContBcnPlus
 		}
 	}
 	RDNode


### PR DESCRIPTION
Note: I only changed the yonguetech config, as recommended in the readme.

All parts were added to the Faster Than Light node. I considered putting the beacon somewhere in the communication line so you could get it before even having FTL travel (to set up your network beforehand), but I don't know where in the tree to put it for balance.